### PR TITLE
discoverer: Gst.init needs an argument

### DIFF
--- a/flumes/discoverer.py
+++ b/flumes/discoverer.py
@@ -52,7 +52,7 @@ class DiscovererOptions(Options):
 
 class Discoverer(object):
     def __init__(self, config, args):
-        Gst.init()
+        Gst.init(None)
 
         self.config = config
         self.loop = GLib.MainLoop()


### PR DESCRIPTION
Fixed: `TypeError: init() missing 1 required positional argument: 'argv'`

The argument is mandatory if [gi/overrides/Gst.py](https://gitlab.freedesktop.org/gstreamer/gst-python/-/blob/1.18.5/gi/overrides/Gst.py#L727) is installed.